### PR TITLE
Fixed bugs in rotation.py and plane.py

### DIFF
--- a/pyray/rotation.py
+++ b/pyray/rotation.py
@@ -235,7 +235,7 @@ def tetrahedral_rotations(p=1.0):
     and the identity or null rotation.
     See comment by Anton Sherwood: https://math.stackexchange.com/a/2582519/155881
     """
-    from pyray.shapes.cube import Cube
+    from pyray.shapes.solid.cube import Cube
 
     c = Cube(3)
     vers = c.vertices

--- a/pyray/shapes/twod/plane.py
+++ b/pyray/shapes/twod/plane.py
@@ -3,6 +3,8 @@ from PIL import Image, ImageDraw, ImageFont, ImageMath
 from pyray.axes import render_scene_4d_axis
 
 from pyray.rotation import *
+from pyray.axes import drawXYGrid, arrowV1
+from pyray.shapes.oned.circle import draw_circle_x_y, project_circle_on_plane
 
 
 def rotated_xz_plane(draw, r, r2, scale=200, shift=np.array([1000,1000,0]), translate=np.array([0,0,0])):


### PR DESCRIPTION
There were some minor issues where the proper module was not imported into the file or when it was imported incorrectly. For instance in rotation.py at line 238 we were trying to import the cube module from the solid folder but forgot to include solid in the import statement